### PR TITLE
Google sheets improvement

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,5 +3,5 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="JSX" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.7 (paris_1970)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8 (paris_1970) (2)" project-jdk-type="Python SDK" />
 </project>

--- a/.idea/paris_1970.iml
+++ b/.idea/paris_1970.iml
@@ -17,7 +17,7 @@
       <sourceFolder url="file://$MODULE_DIR$/backend" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.7 (paris_1970)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.8 (paris_1970) (2)" jdkType="Python SDK" />
     <orderEntry type="jdk" jdkName="Python 3.8 (paris_1970)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/backend/app/management/commands/syncdb.py
+++ b/backend/app/management/commands/syncdb.py
@@ -48,9 +48,7 @@ class Command(BaseCommand):
 
         print_header(f'Will import range {spreadsheet_range}')
 
-        # TODO(ra): clean up authentication pickling routines --
         # Settings for pickle file
-        # do we even want to cache auth to disk? probably not...
 
         creds = None
         # The file token.pickle stores the user's access and refresh tokens, and is
@@ -82,7 +80,6 @@ class Command(BaseCommand):
         result = get_values_cmd.execute()
         values = result.get('values', [])
 
-        # TODO(ra): handle case where the server is running and using the db
         if os.path.exists(settings.DB_PATH):
             print_header('Deleting existing db...')
             os.remove(settings.DB_PATH)
@@ -100,7 +97,6 @@ class Command(BaseCommand):
         else:
             print_header('Importing these values from the spreadsheet')
 
-            # TODO: can we get the data as a dictionary per row (with a header) rather than a list?
             header = values[0]
             values_as_a_dict = [{header[i]: entry for i, entry in enumerate(row)}
                                 for row in values[1:]]

--- a/backend/app/management/commands/syncdb.py
+++ b/backend/app/management/commands/syncdb.py
@@ -46,13 +46,7 @@ class Command(BaseCommand):
         parser.add_argument('--range', action='store', type=str)
 
     def handle(self, *args, **options):
-        # TODO: get the range dynamically -- iterate until we hit a blank row
-        maybe_range = options.get('range', '')
-        if maybe_range:
-            # TODO: validate that this will work
-            spreadsheet_range = 'Sheet1!' + maybe_range
-        else:
-            spreadsheet_range = 'Sheet1!A2:D5'
+        spreadsheet_range = 'Sheet1!A:D'
 
         print_header(f'Will import range {spreadsheet_range}')
 
@@ -108,6 +102,7 @@ class Command(BaseCommand):
             print_header('Importing these values from the spreadsheet')
 
             # TODO: can we get the data as a dictionary per row (with a header) rather than a list?
+            print(values, len(values))
             for row in values:
                 print(row)
                 photo = Photo(

--- a/backend/app/management/commands/syncdb.py
+++ b/backend/app/management/commands/syncdb.py
@@ -51,26 +51,11 @@ class Command(BaseCommand):
         # TODO(ra): clean up authentication pickling routines --
         # do we even want to cache auth to disk? probably not...
 
-        creds = None
-        # The file token.pickle stores the user's access and refresh tokens, and is
-        # created automatically when the authorization flow completes for the first
-        # time.
-        if os.path.exists('token.pickle'):
-            with open('token.pickle', 'rb') as token:
-                creds = pickle.load(token)
-        # If there are no (valid) credentials available, let the user log in.
-        if not creds or not creds.valid:
-            if creds and creds.expired and creds.refresh_token:
-                creds.refresh(Request())
-            else:
-                flow = InstalledAppFlow.from_client_secrets_file(
-                    settings.GOOGLE_API_CREDENTIALS_FILE,
-                    SCOPES
-                )
-                creds = flow.run_local_server(port=8080)
-            # Save the credentials for the next run
-            with open('token.pickle', 'wb') as token:
-                pickle.dump(creds, token)
+        flow = InstalledAppFlow.from_client_secrets_file(
+            settings.GOOGLE_API_CREDENTIALS_FILE,
+            SCOPES
+        )
+        creds = flow.run_local_server(port=8080)
 
         service = build('sheets', 'v4', credentials=creds)
 

--- a/backend/app/management/commands/syncdb.py
+++ b/backend/app/management/commands/syncdb.py
@@ -2,9 +2,7 @@
 Django management command syncdb
 
 Syncs local db with data from project Google Sheet
-
-TODO(ra): link Google Sheet here
-"""
+s"""
 
 
 import pickle
@@ -102,13 +100,16 @@ class Command(BaseCommand):
             print_header('Importing these values from the spreadsheet')
 
             # TODO: can we get the data as a dictionary per row (with a header) rather than a list?
-            print(values, len(values))
-            for row in values:
+            header = values[0]
+            values_as_a_dict = [{header[i]: entry for i, entry in enumerate(row)}
+                                for row in values[1:]]
+
+            for row in values_as_a_dict:
                 print(row)
                 photo = Photo(
-                    title=row[0],
-                    front_src=row[1],
-                    back_src=row[2],
-                    alt=row[3],
+                    title=row["title"],
+                    front_src=row["front_src"],
+                    back_src=row["back_src"],
+                    alt=row["alt"],
                 )
                 photo.save()

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -17,6 +17,7 @@ DB_PATH = os.path.join(BACKEND_DIR, 'db.sqlite3')
 PROJECT_ROOT = os.path.dirname(BACKEND_DIR)
 BACKEND_DATA_DIR = os.path.join(BACKEND_DIR, 'data')
 GOOGLE_API_CREDENTIALS_FILE = os.path.join(SETTINGS_DIR, 'google_api_credentials.json')
+GOOGLE_TOKEN_FILE = os.path.join(BACKEND_DIR, 'token.pickle')
 
 
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/


### PR DESCRIPTION
- Dynamically get the values from the Google sheet using a range value of `Sheet1!A:D`. However, this breaks if a row is missing some values.
- Converted each row from a list into a dictionary where the key is the header value (title, front_src, ...) and the value is the value associated with that header. (There doesn't seem to be a way for the Google Sheets API to return a dictionary)

- For cleaning up the authentication pickling routes, we can just have:
```python
flow = InstalledAppFlow.from_client_secrets_file(
        settings.GOOGLE_API_CREDENTIALS_FILE,
        SCOPES
)
creds = flow.run_local_server(port=8080)
```
and everything works fine, but a new window pops up asking us to choose a Google account every time we run `python manage.py syncdb`

- I'm not sure if it is just me, but I am able to sync the db even when my back end is running.