### PR TITLE
Catching syncdb permission error

### DIFF
--- a/backend/app/management/commands/syncdb.py
+++ b/backend/app/management/commands/syncdb.py
@@ -72,17 +72,19 @@ class Command(BaseCommand):
         # Delete database
         if os.path.exists(settings.DB_PATH):
             print_header('Deleting existing db...')
-            for file in os.listdir(settings.MIGRATIONS_DIR):
-                if file != '__init__.py' and file != '__pycache__':
-                    file_path = os.path.join(settings.MIGRATIONS_DIR, file)
-                    os.remove(file_path)
             try:
                 os.remove(settings.DB_PATH)
             except PermissionError:
                 print_header('''Permission Error: Unable to delete the database file while the
                         backend is running. Please stop the "Run backend" process and try again.''')
                 return
-            print('\nDone!')
+
+        # Delete all migrations
+        for file in os.listdir(settings.MIGRATIONS_DIR):
+            if file != '__init__.py' and file != '__pycache__':
+                file_path = os.path.join(settings.MIGRATIONS_DIR, file)
+                os.remove(file_path)
+        print('Done!')
 
         # The order of these ranges matter. The Photographer model needs to have foreign keys to
         # the MapSquare database, so we add the Map Squares first

--- a/backend/app/management/commands/syncdb.py
+++ b/backend/app/management/commands/syncdb.py
@@ -69,6 +69,21 @@ class Command(BaseCommand):
         parser.add_argument('--range', action='store', type=str)
 
     def handle(self, *args, **options):
+        # Delete database
+        if os.path.exists(settings.DB_PATH):
+            print_header('Deleting existing db...')
+            for file in os.listdir(settings.MIGRATIONS_DIR):
+                if file != '__init__.py' and file != '__pycache__':
+                    file_path = os.path.join(settings.MIGRATIONS_DIR, file)
+                    os.remove(file_path)
+            try:
+                os.remove(settings.DB_PATH)
+            except PermissionError:
+                print_header('''Permission Error: Unable to delete the database file while the
+                        backend is running. Please stop the "Run backend" process and try again.''')
+                return
+            print('\nDone!')
+
         # The order of these ranges matter. The Photographer model needs to have foreign keys to
         # the MapSquare database, so we add the Map Squares first
         spreadsheet_ranges = ['MapSquare', 'Photographer', 'Photo']
@@ -120,21 +135,6 @@ class Command(BaseCommand):
             result = get_values_cmd.execute()
             values = result.get('values', [])
             databases.append(values)
-
-        # Delete database
-        if os.path.exists(settings.DB_PATH):
-            print_header('Deleting existing db...')
-            for file in os.listdir(settings.MIGRATIONS_DIR):
-                if file != '__init__.py' and file != '__pycache__':
-                    file_path = os.path.join(settings.MIGRATIONS_DIR, file)
-                    os.remove(file_path)
-            try:
-                os.remove(settings.DB_PATH)
-            except PermissionError:
-                print_header('''Permission Error: Unable to delete the database file while the
-                backend is running. Please stop the "Run backend" process and try again.''')
-                return
-            print('\nDone!')
 
         # Rebuild database
         print_header('Rebuilding db from migrations...')

--- a/backend/app/management/commands/syncdb.py
+++ b/backend/app/management/commands/syncdb.py
@@ -128,7 +128,12 @@ class Command(BaseCommand):
                 if file != '__init__.py' and file != '__pycache__':
                     file_path = os.path.join(settings.MIGRATIONS_DIR, file)
                     os.remove(file_path)
-            os.remove(settings.DB_PATH)
+            try:
+                os.remove(settings.DB_PATH)
+            except PermissionError:
+                print_header('''Permission Error: Unable to delete the database file while the
+                backend is running. Please stop the "Run backend" process and try again.''')
+                return
             print('\nDone!')
 
         # Rebuild database


### PR DESCRIPTION
- syncdb catches permission error and returns a helpful error message
- syncdb now attempts to the delete database first to avoid unnecessary waiting