### PR TITLE
generates heat map to show photo density in each square

### DIFF
--- a/backend/app/analysis/indoor_analysis/courtyard_frame.py
+++ b/backend/app/analysis/indoor_analysis/courtyard_frame.py
@@ -30,8 +30,7 @@ def analyze(photo: Photo):
     border_percentage = 0.05 #top and bottom 0.5% of photo
     border_num = int(border_percentage * min(len(normalized_grayscale_image[0]), #length
                                              len(normalized_grayscale_image))) #width
-    if border_num < 1:
-        border_num = 1
+    border_num = max(border_num, 1)
 
     # Using half of highest pixel as threshold
     max_pixel = 0

--- a/frontend/src/index/index.js
+++ b/frontend/src/index/index.js
@@ -8,12 +8,13 @@ import {
     ZoomControl,
 } from 'react-leaflet';
 
-
 import {
     Modal,
     Button,
 } from 'react-bootstrap';
 import { Navbar, Footer, LoadingPage } from '../UILibrary/components';
+
+import Legend from '../legend/legend.js';
 
 class Map extends React.Component {
     state = {
@@ -30,12 +31,16 @@ class Map extends React.Component {
         const sortedMapData = Object.values(this.props.mapData)
             .sort((a, b) => a.num_photos - b.num_photos);
         // Gets the max number of photos in a single square out of all squares to form buckets later
-        const maxNumberOfPhotos = sortedMapData[sortedMapData.length - 1].num_photos;
+        const maxNumOfPhotos = sortedMapData[sortedMapData.length - 1].num_photos;
         // Creating 5 buckets based on lowest to highest number of photos per square
-        const twentyPctMax = 0.2 * maxNumberOfPhotos;
-        const fortyPctMax = 0.4 * maxNumberOfPhotos;
-        const sixtyPctMax = 0.6 * maxNumberOfPhotos;
-        const eightyPctMax = 0.8 * maxNumberOfPhotos;
+        const twentyPctMax = Math.round(0.2 * maxNumOfPhotos);
+        const fortyPctMax = Math.round(0.4 * maxNumOfPhotos);
+        const sixtyPctMax = Math.round(0.6 * maxNumOfPhotos);
+        const eightyPctMax = Math.round(0.8 * maxNumOfPhotos);
+        const buckets = [0, twentyPctMax, twentyPctMax + 1,
+            fortyPctMax, fortyPctMax + 1,
+            sixtyPctMax, sixtyPctMax + 1,
+            eightyPctMax, eightyPctMax + 1, maxNumOfPhotos];
 
         return (
             <div id="map-container">
@@ -52,6 +57,7 @@ class Map extends React.Component {
                     zoomControl={false}
                 >
                     <ZoomControl position="bottomleft"/>
+                    <Legend buckets={buckets}/>
                     <TileLayer
                         // Sets Map Boundaries - Keeps user from leaving Paris
                         maxBoundsViscosity={1.0}
@@ -91,7 +97,7 @@ class Map extends React.Component {
                                 mapSquareBucket = 'map-square box-three';
                             } else if (numberOfPhotos <= eightyPctMax) {
                                 mapSquareBucket = 'map-square box-four';
-                            } else if (numberOfPhotos <= maxNumberOfPhotos) {
+                            } else if (numberOfPhotos <= maxNumOfPhotos) {
                                 mapSquareBucket = 'map-square box-five';
                             }
                             // Greys out squares without photos in them
@@ -127,6 +133,7 @@ class Map extends React.Component {
         );
     }
 }
+
 Map.propTypes = {
     mapData: PropTypes.array,
 };
@@ -228,7 +235,7 @@ export class IndexView extends React.Component {
 
         return (<React.Fragment className="landing-page">
             <Navbar />
-            <Map mapData={this.state.mapData}/>
+            <Map mapData={this.state.mapData} />
             <Footer />
         </React.Fragment>);
     }

--- a/frontend/src/index/index.js
+++ b/frontend/src/index/index.js
@@ -31,6 +31,12 @@ class Map extends React.Component {
             .sort((a, b) => a.num_photos - b.num_photos);
         // Gets the max number of photos in a single square out of all squares to form buckets later
         const maxNumberOfPhotos = sortedMapData[sortedMapData.length - 1].num_photos;
+        // Creating 5 buckets based on lowest to highest number of photos per square
+        const twentyPctMax = 0.2 * maxNumberOfPhotos;
+        const fortyPctMax = 0.4 * maxNumberOfPhotos;
+        const sixtyPctMax = 0.6 * maxNumberOfPhotos;
+        const eightyPctMax = 0.8 * maxNumberOfPhotos;
+
         console.log(maxNumberOfPhotos);
         return (
             <div id="map-container">
@@ -78,23 +84,23 @@ class Map extends React.Component {
                             const link = '/map_square/' + index;
                             let mapSquareBucket = '';
                             // set of conditionals to to calculate photo density for heat map
-                            if (numberOfPhotos > 0 && numberOfPhotos <= maxNumberOfPhotos * 0.2) {
+                            if (numberOfPhotos > 0 && numberOfPhotos <= twentyPctMax) {
                                 mapSquareBucket = 'map-square-box-one';
                             }
 
-                            if (numberOfPhotos > maxNumberOfPhotos * 0.2 && numberOfPhotos <= maxNumberOfPhotos * 0.4) {
+                            if (numberOfPhotos > twentyPctMax && numberOfPhotos <= fortyPctMax) {
                                 mapSquareBucket = 'map-square-box-two';
                             }
 
-                            if (numberOfPhotos > maxNumberOfPhotos * 0.4 && numberOfPhotos <= maxNumberOfPhotos * 0.6) {
+                            if (numberOfPhotos > fortyPctMax && numberOfPhotos <= sixtyPctMax) {
                                 mapSquareBucket = 'map-square-box-three';
                             }
 
-                            if (numberOfPhotos > maxNumberOfPhotos * 0.6 && numberOfPhotos <= maxNumberOfPhotos * 0.8) {
+                            if (numberOfPhotos > sixtyPctMax && numberOfPhotos <= eightyPctMax) {
                                 mapSquareBucket = 'map-square-box-four';
                             }
 
-                            if (numberOfPhotos > maxNumberOfPhotos * 0.8 && numberOfPhotos <= maxNumberOfPhotos) {
+                            if (numberOfPhotos > eightyPctMax) {
                                 mapSquareBucket = 'map-square-box-five';
                             }
                             // Greys out squares without photos in them
@@ -114,15 +120,15 @@ class Map extends React.Component {
 
                             return (
                                 <Rectangle className={mapSquareBucket}
-                                           key={index}
-                                           bounds={mapSquareBounds}
+                                    key={index}
+                                    bounds={mapSquareBounds}
                                 >
                                     <Popup>
-                                            Map Square {index} <br />
-                                            <a href={link}>{numberOfPhotos} photos to show</a>
+                                        Map Square {index} <br />
+                                        <a href={link}>{numberOfPhotos} photos to show</a>
                                     </Popup>
                                 </Rectangle>
-                                );
+                            );
                         })
                     }
                 </LeafletMap>

--- a/frontend/src/index/index.js
+++ b/frontend/src/index/index.js
@@ -37,7 +37,6 @@ class Map extends React.Component {
         const sixtyPctMax = 0.6 * maxNumberOfPhotos;
         const eightyPctMax = 0.8 * maxNumberOfPhotos;
 
-        console.log(maxNumberOfPhotos);
         return (
             <div id="map-container">
                 <Instructions />
@@ -85,23 +84,15 @@ class Map extends React.Component {
                             let mapSquareBucket = '';
                             // set of conditionals to to calculate photo density for heat map
                             if (numberOfPhotos > 0 && numberOfPhotos <= twentyPctMax) {
-                                mapSquareBucket = 'map-square-box-one';
-                            }
-
-                            if (numberOfPhotos > twentyPctMax && numberOfPhotos <= fortyPctMax) {
-                                mapSquareBucket = 'map-square-box-two';
-                            }
-
-                            if (numberOfPhotos > fortyPctMax && numberOfPhotos <= sixtyPctMax) {
-                                mapSquareBucket = 'map-square-box-three';
-                            }
-
-                            if (numberOfPhotos > sixtyPctMax && numberOfPhotos <= eightyPctMax) {
-                                mapSquareBucket = 'map-square-box-four';
-                            }
-
-                            if (numberOfPhotos > eightyPctMax) {
-                                mapSquareBucket = 'map-square-box-five';
+                                mapSquareBucket = 'map-square box-one';
+                            } else if (numberOfPhotos <= fortyPctMax) {
+                                mapSquareBucket = 'map-square box-two';
+                            } else if (numberOfPhotos <= sixtyPctMax) {
+                                mapSquareBucket = 'map-square box-three';
+                            } else if (numberOfPhotos <= eightyPctMax) {
+                                mapSquareBucket = 'map-square box-four';
+                            } else if (numberOfPhotos <= maxNumberOfPhotos) {
+                                mapSquareBucket = 'map-square box-five';
                             }
                             // Greys out squares without photos in them
                             if (numberOfPhotos === 0) {
@@ -237,7 +228,7 @@ export class IndexView extends React.Component {
 
         return (<React.Fragment className="landing-page">
             <Navbar />
-            <Map mapData={this.state.mapData} />
+            <Map mapData={this.state.mapData}/>
             <Footer />
         </React.Fragment>);
     }

--- a/frontend/src/index/index.js
+++ b/frontend/src/index/index.js
@@ -8,6 +8,7 @@ import {
     ZoomControl,
 } from 'react-leaflet';
 
+
 import {
     Modal,
     Button,
@@ -23,11 +24,14 @@ class Map extends React.Component {
         minZoom: 12,
     }
 
+
     render() {
         // Sorts the map squares by number of photos (ascending order)
         const sortedMapData = Object.values(this.props.mapData)
             .sort((a, b) => a.num_photos - b.num_photos);
-
+        // Gets the max number of photos in a single square out of all squares to form buckets later
+        const maxNumberOfPhotos = sortedMapData[sortedMapData.length - 1].num_photos;
+        console.log(maxNumberOfPhotos);
         return (
             <div id="map-container">
                 <Instructions />
@@ -63,7 +67,6 @@ class Map extends React.Component {
                             const index = mapSquareData.number;
                             const coords = mapSquareData.topLeftCoords;
                             const numberOfPhotos = mapSquareData.num_photos;
-
                             // Width and height of map squares
                             const lngDiff = 0.00340325568;
                             const latDiff = 0.0022358;
@@ -73,7 +76,27 @@ class Map extends React.Component {
                                 [coords.lat - latDiff, coords.lng - lngDiff],
                             ];
                             const link = '/map_square/' + index;
+                            let mapSquareBucket = '';
+                            // set of conditionals to to calculate photo density for heat map
+                            if (numberOfPhotos > 0 && numberOfPhotos <= maxNumberOfPhotos * 0.2) {
+                                mapSquareBucket = 'map-square-box-one';
+                            }
 
+                            if (numberOfPhotos > maxNumberOfPhotos * 0.2 && numberOfPhotos <= maxNumberOfPhotos * 0.4) {
+                                mapSquareBucket = 'map-square-box-two';
+                            }
+
+                            if (numberOfPhotos > maxNumberOfPhotos * 0.4 && numberOfPhotos <= maxNumberOfPhotos * 0.6) {
+                                mapSquareBucket = 'map-square-box-three';
+                            }
+
+                            if (numberOfPhotos > maxNumberOfPhotos * 0.6 && numberOfPhotos <= maxNumberOfPhotos * 0.8) {
+                                mapSquareBucket = 'map-square-box-four';
+                            }
+
+                            if (numberOfPhotos > maxNumberOfPhotos * 0.8 && numberOfPhotos <= maxNumberOfPhotos) {
+                                mapSquareBucket = 'map-square-box-five';
+                            }
                             // Greys out squares without photos in them
                             if (numberOfPhotos === 0) {
                                 return (
@@ -88,17 +111,18 @@ class Map extends React.Component {
                                     </Rectangle>
                                 );
                             }
+
                             return (
-                                <Rectangle className="map-square-box"
-                                    key={index}
-                                    bounds={mapSquareBounds}
+                                <Rectangle className={mapSquareBucket}
+                                           key={index}
+                                           bounds={mapSquareBounds}
                                 >
                                     <Popup>
-                                        Map Square {index} <br/>
-                                        <a href={link}>{numberOfPhotos} photos to show</a>
+                                            Map Square {index} <br />
+                                            <a href={link}>{numberOfPhotos} photos to show</a>
                                     </Popup>
                                 </Rectangle>
-                            );
+                                );
                         })
                     }
                 </LeafletMap>

--- a/frontend/src/index/index.scss
+++ b/frontend/src/index/index.scss
@@ -76,38 +76,32 @@ code {
     stroke-opacity: 0.5;
 }
 
-//.map-square-box {
-//    stroke: steelblue;
-//    stroke-width: 2.8;
-//    fill: dodgerblue;
-//    fill-opacity: 0.3;
-//}
 .map-square {
     stroke-width: 2.8;
     fill-opacity: 0.5;
 }
 
-.map-square-box-one {
+.box-one {
     stroke: #E85285;
     fill: #E85285;
 }
 
-.map-square-box-two {
+.box-two {
     stroke: #C9458B;
     fill: #C9458B;
 }
 
-.map-square-box-three {
+.box-three {
     stroke: #A93790;
     fill: #A93790;
 }
 
-.map-square-box-four {
+.box-four {
     stroke: #8A2995;
     fill: #8A2995;
 }
 
-.map-square-box-five {
+.box-five {
     stroke: #6A1B9A;
     fill: #6A1B9A;
 }

--- a/frontend/src/index/index.scss
+++ b/frontend/src/index/index.scss
@@ -76,9 +76,38 @@ code {
     stroke-opacity: 0.5;
 }
 
-.map-square-box {
-    stroke: steelblue;
+//.map-square-box {
+//    stroke: steelblue;
+//    stroke-width: 2.8;
+//    fill: dodgerblue;
+//    fill-opacity: 0.3;
+//}
+.map-square {
     stroke-width: 2.8;
-    fill: dodgerblue;
-    fill-opacity: 0.3;
+    fill-opacity: 0.5;
+}
+
+.map-square-box-one {
+    stroke: #E85285;
+    fill: #E85285;
+}
+
+.map-square-box-two {
+    stroke: #C9458B;
+    fill: #C9458B;
+}
+
+.map-square-box-three {
+    stroke: #A93790;
+    fill: #A93790;
+}
+
+.map-square-box-four {
+    stroke: #8A2995;
+    fill: #8A2995;
+}
+
+.map-square-box-five {
+    stroke: #6A1B9A;
+    fill: #6A1B9A;
 }

--- a/frontend/src/legend/legend.js
+++ b/frontend/src/legend/legend.js
@@ -26,7 +26,7 @@ class Legend extends MapControl {
         const legend = L.control({ position: 'topright' });
 
         legend.onAdd = () => {
-            const div = L.DomUtil.create('div', 'info legend');
+            const div = L.DomUtil.create('div', 'heat-map-info heat-map-legend');
             const grades = this.props.buckets;
             const labels = [];
             let d = 0;

--- a/frontend/src/legend/legend.js
+++ b/frontend/src/legend/legend.js
@@ -1,0 +1,55 @@
+import { MapControl, withLeaflet } from 'react-leaflet';
+import L from 'leaflet';
+import './legend.scss';
+
+class Legend extends MapControl {
+    createLeafletElement(_props) {}
+
+    componentDidMount() {
+        // get color depending on the bucket that corresponds with the number of photos
+        const getColor = (d) => {
+            if (d === 1) {
+                return '#E85285';
+            }
+            if (d === 2) {
+                return '#C9458B';
+            }
+            if (d === 3) {
+                return '#A93790';
+            }
+            if (d === 4) {
+                return '#8A2995';
+            }
+            return '#6A1B9A';
+        };
+
+        const legend = L.control({ position: 'topright' });
+
+        legend.onAdd = () => {
+            const div = L.DomUtil.create('div', 'info legend');
+            const grades = this.props.buckets;
+            const labels = [];
+            let d = 0;
+
+            for (let i = 0; i < 9; i += 2) {
+                d += 1;
+
+                labels.push(
+                    '<i style="background:' + getColor(d) + '"></i> '
+                    + grades[i] + '&ndash;' + grades[i + 1],
+                );
+            }
+
+            div.innerHTML = '<h6>Photo Density</h6>';
+            div.innerHTML += '(photos/square)<br/>';
+            div.innerHTML += labels.join('<br/>');
+            return div;
+        };
+
+        const { map } = this.props.leaflet;
+        legend.addTo(map);
+    }
+}
+
+export default withLeaflet(Legend);
+

--- a/frontend/src/legend/legend.scss
+++ b/frontend/src/legend/legend.scss
@@ -1,8 +1,4 @@
-body {
-  margin: 0px;
-}
-
-.info {
+.heat-map-info {
   padding: 6px 8px;
   font: 14px/16px Arial, Helvetica, sans-serif;
   background: white;
@@ -11,22 +7,22 @@ body {
   border-radius: 5px;
 }
 
-.info h4 {
+.heat-map-info h4 {
   margin: 0 0 5px;
   color: #777;
 }
 
-.info h6 {
+.heat-map-info h6 {
     margin: 0;
 }
 
-.legend {
+.heat-map-legend {
   text-align: left;
   line-height: 18px;
   color: #555;
 }
 
-.legend i {
+.heat-map-legend i {
   width: 18px;
   height: 18px;
   float: left;

--- a/frontend/src/legend/legend.scss
+++ b/frontend/src/legend/legend.scss
@@ -1,0 +1,35 @@
+body {
+  margin: 0px;
+}
+
+.info {
+  padding: 6px 8px;
+  font: 14px/16px Arial, Helvetica, sans-serif;
+  background: white;
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.2);
+  border-radius: 5px;
+}
+
+.info h4 {
+  margin: 0 0 5px;
+  color: #777;
+}
+
+.info h6 {
+    margin: 0;
+}
+
+.legend {
+  text-align: left;
+  line-height: 18px;
+  color: #555;
+}
+
+.legend i {
+  width: 18px;
+  height: 18px;
+  float: left;
+  margin-right: 8px;
+  opacity: 0.7;
+}


### PR DESCRIPTION
The map on the home page is now colored in based on a gradient of 5 colors (buckets). These buckets represent the density of photos in the square, calculated as a percentage of the number of photos in the square with the maximum number out of all of the squares. Currently, the colors go from pink (0%) to purple (100% of the max). 

Because the bucket sizes (photos per bucket) are calculated as a percentage of the max photos, they should not need to be altered in the future as more photos are added to the database. 

There is also a legend to help the user navigate which colors (buckets) correspond which range of number of photos for the square, as seen in the top right. 

<img width="1276" alt="Screen Shot 2021-04-23 at 1 39 27 PM" src="https://user-images.githubusercontent.com/52471965/115909310-5a4cb600-a439-11eb-9b99-6e64e6d2d33c.png">