### PR TITLE
Limit Similar Photos

### DIFF
--- a/backend/app/serializers.py
+++ b/backend/app/serializers.py
@@ -53,7 +53,11 @@ class PhotoSerializer(serializers.ModelSerializer):
         for analysis_result in analysis_results:
             name = analysis_result['name']
             result = json.loads(analysis_result['result'])
-            analyses_dict[name] = result
+            if name == "photo_similarity.resnet18_cosine_similarity":
+                analyses_dict[name] = result[:min(10, len(result))]
+            else:
+                analyses_dict[name] = result
+            
         return analyses_dict
 
     @staticmethod

--- a/backend/app/serializers.py
+++ b/backend/app/serializers.py
@@ -54,7 +54,7 @@ class PhotoSerializer(serializers.ModelSerializer):
             name = analysis_result['name']
             result = json.loads(analysis_result['result'])
             if name == "photo_similarity.resnet18_cosine_similarity":
-                analyses_dict[name] = result[:min(10, len(result))]
+                analyses_dict[name] = result[:10]
             else:
                 analyses_dict[name] = result
             

--- a/frontend/components/PhotoViewer.js
+++ b/frontend/components/PhotoViewer.js
@@ -41,8 +41,6 @@ export class PhotoViewer extends React.Component {
             }
         );
         return photoData.map((photo, k) => {
-            // TODO: This is where we cap up to 10 photos. Maybe this needs to live on the backend?
-            if (k >= 10) return <></>;
             return (
                 <li className={`default-photo photo-item-background text-center list-inline-item ${className}`}
                     key={k}


### PR DESCRIPTION
This PR limits the number of similar photos shown on the single photo page to 10. Instead of doing this on the frontend, it's now done on the backend.