### PR TITLE
Adding search by name to photographers page

### DIFF
--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -105,15 +105,19 @@ def search_photographers(request):
     """
     API endpoint to get a list of photographers based on a search query that looks the photographers by name 
     If not given a search query it will return the first 50 photographers sorted by name
+
+    TODO: Add pagination for both cases (when given a search query and when nothing is given) 
+    so that the user is sent the first 50 results and they can view more results as they scroll down the page.
     """
     name = request.GET.get("name", None)
-    if name is not None or name.strip() != "":
+    is_searching_by_name = name is not None and name.strip() != ""
+    if is_searching_by_name:
         matching_photographers = Photographer.objects.filter(name__icontains=name)
     else:
         matching_photographers = Photographer.objects.all()
 
-    page_limit = 50
-    serialized_photographers = PhotographerSearchSerializer(matching_photographers.order_by("name")[:page_limit], many=True) # add pagination here
+    ordered_capped_photographers = matching_photographers.order_by("name")[:50] if not is_searching_by_name else matching_photographers.order_by("name")
+    serialized_photographers = PhotographerSearchSerializer(ordered_capped_photographers, many=True) # add pagination here
     res = Response(serialized_photographers.data)
     return res
 

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -116,8 +116,13 @@ def search_photographers(request):
     else:
         matching_photographers = Photographer.objects.all()
 
-    ordered_capped_photographers = matching_photographers.order_by("name")[:50] if not is_searching_by_name else matching_photographers.order_by("name")
-    serialized_photographers = PhotographerSearchSerializer(ordered_capped_photographers, many=True) # add pagination here
+    ordered_capped_photographers = (
+        matching_photographers.order_by("name")[:50] 
+        if not is_searching_by_name else matching_photographers.order_by("name")
+    )
+    serialized_photographers = (
+        PhotographerSearchSerializer(ordered_capped_photographers, many=True)
+    ) # add pagination here
     res = Response(serialized_photographers.data)
     return res
 

--- a/backend/app/views.py
+++ b/backend/app/views.py
@@ -112,16 +112,12 @@ def search_photographers(request):
     name = request.GET.get("name", None)
     is_searching_by_name = name is not None and name.strip() != ""
     if is_searching_by_name:
-        matching_photographers = Photographer.objects.filter(name__icontains=name)
+        matching_photographers = Photographer.objects.filter(name__icontains=name).order_by("name")
     else:
-        matching_photographers = Photographer.objects.all()
+        matching_photographers = Photographer.objects.all().order_by("name")[:50]
 
-    ordered_capped_photographers = (
-        matching_photographers.order_by("name")[:50] 
-        if not is_searching_by_name else matching_photographers.order_by("name")
-    )
     serialized_photographers = (
-        PhotographerSearchSerializer(ordered_capped_photographers, many=True)
+        PhotographerSearchSerializer(matching_photographers, many=True)
     ) # add pagination here
     res = Response(serialized_photographers.data)
     return res

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -50,6 +50,7 @@ urlpatterns = [
     path('api/all_photos/', views.all_photos, name="all_photos"),
 
     # Photographers
+   	path('api/search_photographers/', views.search_photographers),
     path('api/photographer/', views.get_photographer, name="all_photographers"),
     path('api/photographer/<int:photographer_number>/', views.get_photographer,
          name='photographer'),

--- a/backend/scripts/directory_lister.py
+++ b/backend/scripts/directory_lister.py
@@ -1,12 +1,8 @@
-import os
-import subprocess
 import sys
 from pathlib import Path
 
-from tqdm import tqdm
 
-
-def convert(src_dir_path, dest_dir_path, commands=['-quality', '20%']):
+def convert(src_dir_path, dest_dir_path):
     """
     Python script for image conversion using Image Magick
     
@@ -16,15 +12,13 @@ def convert(src_dir_path, dest_dir_path, commands=['-quality', '20%']):
     :return: None, output produced in new directory
     """
 
-    magick_commands = []
     for src_sub_dir in src_dir_path.iterdir():
-        if not src_sub_dir.is_dir(): continue
+        if not src_sub_dir.is_dir(): 
+            continue
 
         dest_sub_dir = Path(dest_dir_path, src_sub_dir.name)
         if not dest_sub_dir.exists():
             dest_sub_dir.mkdir()
-
-        magick_args = ' ' .join(commands)
 
         # looping through old directory
         for src_image_path in src_sub_dir.iterdir():
@@ -34,13 +28,14 @@ def convert(src_dir_path, dest_dir_path, commands=['-quality', '20%']):
                 continue
 
             dest_image_path = Path(dest_sub_dir, src_image_path.stem + '.jpg')
-            if dest_image_path.exists(): continue
+            if dest_image_path.exists(): 
+                continue
 
 if __name__ == "__main__":
-    src_dir_path = Path(sys.argv[1])
-    commands_arg = sys.argv[3:]
+    src_path = Path(sys.argv[1])
+    dest_path = Path(sys.argv[1])
 
-    convert(src_dir_path, dest_dir_path, commands_arg)
+    convert(src_path, dest_path)
 
 """
 # Example of command-line:

--- a/backend/scripts/paris_metadata_csv_generator.py
+++ b/backend/scripts/paris_metadata_csv_generator.py
@@ -1,5 +1,3 @@
-import os
-import subprocess
 import sys
 from pathlib import Path
 
@@ -34,6 +32,6 @@ def main(src_dir_path, dest_dir_path):
         out_csv.close()
 
 if __name__ == "__main__":
-    src_dir_path = Path(sys.argv[1])
-    dest_dir_path = Path(sys.argv[2])
-    main(src_dir_path, dest_dir_path)
+    src_path = Path(sys.argv[1])
+    dest_path = Path(sys.argv[2])
+    main(src_path, dest_path)

--- a/backend/scripts/paris_metadata_csv_generator.py
+++ b/backend/scripts/paris_metadata_csv_generator.py
@@ -9,7 +9,8 @@ def main(src_dir_path, dest_dir_path):
     Creates CSV file templates for the map square entry process
     """
     for src_sub_dir in src_dir_path.iterdir():
-        if not src_sub_dir.is_dir(): continue
+        if not src_sub_dir.is_dir():
+            continue
 
         map_square_folder_url = src_sub_dir.name
         folder_number = '_'.join(map_square_folder_url.split('_')[-2:])

--- a/frontend/pages/views/PhotographerListView.js
+++ b/frontend/pages/views/PhotographerListView.js
@@ -1,23 +1,39 @@
 import React from "react";
 import Footer from "../../components/Footer";
 import * as PropTypes from "prop-types";
-
+import { debounce } from "../../common";
 
 export class PhotographerListView extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            photographers: JSON.parse(this.props.photographers)
+            photographers: [],
         };
     }
 
     hrefFunc(number) {
         return `/photographer/${number}`;
-    };
+    }
 
     srcFunc(number) {
         return `${this.props.photoListDir}/${number}_photo.jpg`;
-    };
+    }
+
+    updatePhotographers(name) {
+        debounce(async () => {
+            const fetchedPhotographers = await this.fetchPhotographers(name);
+            this.setState({ photographers: fetchedPhotographers });
+        }, 300)();
+    }
+
+    async fetchPhotographers(sq) {
+        try {
+            const res = await fetch(`/api/search_photographers?name=${sq}`);
+            return res.json();
+        } catch {
+            return [];
+        }
+    }
 
     getPhotoList() {
         const photoSize = [100, 100];
@@ -25,44 +41,57 @@ export class PhotographerListView extends React.Component {
             return (
                 <li className="col-2 col-lg-2 one-photographer list-inline-item" key={k}>
                     <div className="child">
-                        <a key={k}
-                           href={this.hrefFunc(photog.number)}>
+                        <a key={k} href={this.hrefFunc(photog.number)}>
                             <img
                                 alt={photog.number}
                                 width={photoSize[0]}
-                                src={this.srcFunc(photog.number)}/>
+                                src={this.srcFunc(photog.number)}
+                            />
                         </a>
                         <p>{photog.name ? photog.name : "No Name"}</p>
                     </div>
                 </li>
             );
         });
+    }
 
+    componentDidMount() {
+        this.updatePhotographers("");
     }
 
     render() {
         return (
             <>
                 <div className="row">
-                    <p style={{
-                        fontSize: "30px",
-                        fontWeight: "600"
-                    }}>Photographers</p>
+                    <p
+                        style={{
+                            fontSize: "30px",
+                            fontWeight: "600",
+                        }}
+                    >
+                        Photographers
+                    </p>
+                </div>
+                <div>
+                    Search By Name:{" "}
+                    <input
+                        onChange={(e) => {
+                            this.updatePhotographers(e.target.value);
+                        }}
+                    />
                 </div>
                 <div className="row">
                     <ul className="list-inline">{this.getPhotoList()}</ul>
                 </div>
                 <div>
-                    <Footer/>
+                    <Footer />
                 </div>
             </>
         );
     }
 }
 
-
 PhotographerListView.propTypes = {
     photoListDir: PropTypes.string,
-    photographers: PropTypes.string
+    photographers: PropTypes.string,
 };
-

--- a/frontend/pages/views/PhotographerListView.js
+++ b/frontend/pages/views/PhotographerListView.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Footer from "../../components/Footer";
 import * as PropTypes from "prop-types";
-import { debounce } from "../../common";
+import {debounce} from "../../common";
 
 export class PhotographerListView extends React.Component {
     constructor(props) {
@@ -22,7 +22,7 @@ export class PhotographerListView extends React.Component {
     updatePhotographers(name) {
         debounce(async () => {
             const fetchedPhotographers = await this.fetchPhotographers(name);
-            this.setState({ photographers: fetchedPhotographers });
+            this.setState({photographers: fetchedPhotographers});
         }, 300)();
     }
 

--- a/frontend/pages/views/PhotographerListView.js
+++ b/frontend/pages/views/PhotographerListView.js
@@ -20,35 +20,34 @@ export class PhotographerListView extends React.Component {
     }
 
     updatePhotographers(name) {
+        const fetchPhotographers = async (sq) => {
+            try {
+                const res = await fetch(`/api/search_photographers?name=${sq}`);
+                return res.json();
+            } catch {
+                return [];
+            }
+        };
         debounce(async () => {
-            const fetchedPhotographers = await this.fetchPhotographers(name);
+            const fetchedPhotographers = await fetchPhotographers(name);
             this.setState({photographers: fetchedPhotographers});
         }, 300)();
     }
 
-    async fetchPhotographers(sq) {
-        try {
-            const res = await fetch(`/api/search_photographers?name=${sq}`);
-            return res.json();
-        } catch {
-            return [];
-        }
-    }
-
     getPhotoList() {
         const photoSize = [100, 100];
-        return this.state.photographers.map((photog, k) => {
+        return this.state.photographers.map((photographer, k) => {
             return (
                 <li className="col-2 col-lg-2 one-photographer list-inline-item" key={k}>
                     <div className="child">
-                        <a key={k} href={this.hrefFunc(photog.number)}>
+                        <a key={k} href={this.hrefFunc(photographer.number)}>
                             <img
-                                alt={photog.number}
+                                alt={photographer.number}
                                 width={photoSize[0]}
-                                src={this.srcFunc(photog.number)}
+                                src={this.srcFunc(photographer.number)}
                             />
                         </a>
-                        <p>{photog.name ? photog.name : "No Name"}</p>
+                        <p>{photographer.name ? photographer.name : "No Name"}</p>
                     </div>
                 </li>
             );
@@ -73,7 +72,7 @@ export class PhotographerListView extends React.Component {
                     </p>
                 </div>
                 <div>
-                    Search By Name:{" "}
+                    Search By Name:&nbsp;
                     <input
                         onChange={(e) => {
                             this.updatePhotographers(e.target.value);


### PR DESCRIPTION
Created a new Django API endpoint to search the photographers by their name. Added a search bar on the front end that utilizes the endpoint and stores the photographers that match the search query as a state instead of capturing it from the props passed from the Django views. Currently, if no search query is given, the page only displays the first 50 photographers, otherwise, it displays all of the photographers who match the given query. 

This approach still has some inefficiencies because if you look up "a" the page will load all of the photographers with the letter "a" in them, but the next step after merging this pr would be to add pagination to these results so that the user can load them incrementally as they need to by scrolling to the bottom of the page. 

Below is how the search bar currently looks like. Planning on reimplementing it after the design is finalized and we implement search by photographer location on the backend. 

<img width="1087" alt="Screen Shot 2022-10-07 at 4 27 40 PM" src="https://user-images.githubusercontent.com/58854232/194647701-8555895e-9f15-4c09-82b3-b9c2edecdb52.png">
 